### PR TITLE
fix(security): harden device key permissions, deduplicate crypto constants, add integration tests

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -64,3 +64,6 @@ tokio = { version = "1", features = ["sync"] }
 reqwest = { version = "0.12", features = ["json", "native-tls"] }
 hex = "0.4"
 
+[dev-dependencies]
+tempfile = "3"
+

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -6,8 +6,7 @@ use crate::error::AppError;
 use crate::models::user::User;
 use crate::state::AppState;
 
-/// Static salt used for blind indexing of emails.
-const BLIND_INDEX_SALT: &[u8] = b"SaladVault_Email_Salt_v1";
+use crate::crypto::blind_index::EMAIL_BLIND_INDEX_SALT;
 
 /// Register a new user account (Potager).
 #[tauri::command]
@@ -16,7 +15,7 @@ pub async fn register(
     master_password: String,
     state: State<'_, AppState>,
 ) -> Result<(), AppError> {
-    let user_id = blind_index::compute_blind_index(&email, BLIND_INDEX_SALT)?;
+    let user_id = blind_index::compute_blind_index(&email, EMAIL_BLIND_INDEX_SALT)?;
 
     // Check if user already exists BEFORE generating a new device key.
     // Otherwise, save_device_key would overwrite the existing key and
@@ -80,7 +79,7 @@ pub async fn unlock(
     master_password: String,
     state: State<'_, AppState>,
 ) -> Result<(), AppError> {
-    let user_id = blind_index::compute_blind_index(&email, BLIND_INDEX_SALT)?;
+    let user_id = blind_index::compute_blind_index(&email, EMAIL_BLIND_INDEX_SALT)?;
 
     let device_key_path = state.device_key_path();
     let device_key = keys::load_device_key(&device_key_path)?;

--- a/src-tauri/src/crypto/blind_index.rs
+++ b/src-tauri/src/crypto/blind_index.rs
@@ -6,8 +6,18 @@ use crate::error::AppError;
 type HmacSha256 = Hmac<Sha256>;
 
 /// Static pepper compiled into the binary for HMAC-SHA256 blind indexing.
-/// In production, this should be a securely generated, long-lived secret.
+///
+/// Threat model: this is a compile-time constant by design. The blind index
+/// must be deterministic across all installations so the server can match
+/// users without seeing their email. Knowing the pepper only allows offline
+/// brute-force enumeration against email dictionaries — it does NOT reveal
+/// stored data. Acceptable risk for a local-first desktop app.
 const PEPPER: &[u8] = b"SaladVault_BlindIndex_Pepper_v1";
+
+/// Domain-separation salt for email blind indexing.
+/// Must be identical across all installations for index consistency.
+/// This is NOT a secret — it prevents cross-domain collisions.
+pub const EMAIL_BLIND_INDEX_SALT: &[u8] = b"SaladVault_Email_Salt_v1";
 
 /// Compute a blind index for an email address.
 /// Uses HMAC-SHA256(pepper, normalize(email) + static_salt) to produce a

--- a/src-tauri/src/crypto/keys.rs
+++ b/src-tauri/src/crypto/keys.rs
@@ -15,12 +15,22 @@ pub fn generate_device_key() -> [u8; 32] {
 }
 
 /// Save the device key to disk at the specified path.
+/// On Unix, restricts file permissions to owner-only (0o600).
 pub fn save_device_key(key: &[u8; 32], path: &Path) -> Result<(), AppError> {
     // Ensure parent directory exists
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
     std::fs::write(path, key)?;
+
+    // Restrict to owner-read/write only on Unix (Windows uses ACLs via %APPDATA%)
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = std::fs::Permissions::from_mode(0o600);
+        std::fs::set_permissions(path, perms)?;
+    }
+
     Ok(())
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,7 +1,7 @@
 mod commands;
-mod crypto;
+pub mod crypto;
 mod db;
-mod error;
+pub mod error;
 mod models;
 mod state;
 mod sync;

--- a/src-tauri/src/sync/commands.rs
+++ b/src-tauri/src/sync/commands.rs
@@ -13,7 +13,7 @@ use crate::sync::client::{
 };
 use crate::sync::{export, import, recovery};
 
-const EMAIL_SALT: &[u8] = b"SaladVault_Email_Salt_v1";
+use crate::crypto::blind_index::EMAIL_BLIND_INDEX_SALT;
 
 // ── Response types for the frontend ──
 
@@ -136,7 +136,7 @@ pub async fn server_register(
     state: State<'_, AppState>,
     args: ServerRegisterArgs,
 ) -> Result<MfaSetupInfo, AppError> {
-    let blind_id = blind_index::compute_blind_index(&args.email, EMAIL_SALT)?;
+    let blind_id = blind_index::compute_blind_index(&args.email, EMAIL_BLIND_INDEX_SALT)?;
     let auth_salt = argon2_kdf::generate_salt();
     let auth_hash = compute_server_auth(args.server_password, auth_salt.to_vec()).await?;
 
@@ -239,7 +239,7 @@ pub async fn server_login(
     state: State<'_, AppState>,
     args: ServerLoginArgs,
 ) -> Result<MfaChallengeInfo, AppError> {
-    let blind_id = blind_index::compute_blind_index(&args.email, EMAIL_SALT)?;
+    let blind_id = blind_index::compute_blind_index(&args.email, EMAIL_BLIND_INDEX_SALT)?;
 
     // Save API URL
     {

--- a/src-tauri/tests/integration.rs
+++ b/src-tauri/tests/integration.rs
@@ -1,0 +1,142 @@
+//! Integration tests for the SaladVault crypto pipeline.
+//!
+//! Tests the full Dual-Lock cycle:
+//!   generate device key -> save/load -> reconstruct master key -> encrypt -> decrypt
+//! Also validates blind index consistency across modules.
+
+use rust_app_lib::crypto::{argon2_kdf, blind_index, keys, xchacha};
+use tempfile::TempDir;
+
+/// Full Dual-Lock cycle: key generation, persistence, master key reconstruction,
+/// and XChaCha20-Poly1305 encrypt/decrypt roundtrip.
+#[test]
+fn test_dual_lock_full_cycle() {
+    let tmp = TempDir::new().unwrap();
+    let key_path = tmp.path().join("device_secret.key");
+
+    // 1. Generate and save the device key
+    let device_key = keys::generate_device_key();
+    keys::save_device_key(&device_key, &key_path).unwrap();
+
+    // 2. Load it back and verify identity
+    let loaded_key = keys::load_device_key(&key_path).unwrap();
+    assert_eq!(device_key, loaded_key);
+
+    // 3. Reconstruct master key via Argon2id + HKDF
+    let password = b"MyStr0ngP@ssw0rd!";
+    let salt = argon2_kdf::generate_salt();
+    let master_key = keys::reconstruct_master_key(password, &device_key, &salt).unwrap();
+
+    // 4. Encrypt some data (simulating a Feuille)
+    let plaintext = b"username: alice\npassword: s3cret_v4lue";
+    let (nonce, ciphertext) = xchacha::encrypt(master_key.as_bytes(), plaintext).unwrap();
+
+    // 5. Decrypt and verify roundtrip
+    let decrypted = xchacha::decrypt(master_key.as_bytes(), &nonce, &ciphertext).unwrap();
+    assert_eq!(decrypted, plaintext);
+
+    // 6. Wrong key must fail decryption
+    let wrong_key = [0xFFu8; 32];
+    assert!(xchacha::decrypt(&wrong_key, &nonce, &ciphertext).is_err());
+}
+
+/// Verify that reconstructing the master key is deterministic:
+/// same inputs always produce the same key.
+#[test]
+fn test_master_key_deterministic_reconstruction() {
+    let password = b"deterministic_test";
+    let device_key = [0xABu8; 32];
+    let salt = [0xCDu8; 32];
+
+    let mk1 = keys::reconstruct_master_key(password, &device_key, &salt).unwrap();
+    let mk2 = keys::reconstruct_master_key(password, &device_key, &salt).unwrap();
+    assert_eq!(mk1.as_bytes(), mk2.as_bytes());
+}
+
+/// Changing any single input to the Dual-Lock must produce a different master key.
+#[test]
+fn test_dual_lock_sensitivity() {
+    let password = b"base_password";
+    let device_key = [0x42u8; 32];
+    let salt = [0x00u8; 32];
+
+    let base = keys::reconstruct_master_key(password, &device_key, &salt).unwrap();
+
+    // Different password
+    let diff_pwd = keys::reconstruct_master_key(b"other_password", &device_key, &salt).unwrap();
+    assert_ne!(base.as_bytes(), diff_pwd.as_bytes());
+
+    // Different device key
+    let mut other_dk = [0x42u8; 32];
+    other_dk[0] = 0x43;
+    let diff_dk = keys::reconstruct_master_key(password, &other_dk, &salt).unwrap();
+    assert_ne!(base.as_bytes(), diff_dk.as_bytes());
+
+    // Different salt
+    let mut other_salt = [0x00u8; 32];
+    other_salt[0] = 0x01;
+    let diff_salt = keys::reconstruct_master_key(password, &device_key, &other_salt).unwrap();
+    assert_ne!(base.as_bytes(), diff_salt.as_bytes());
+}
+
+/// Blind index must be consistent when using the canonical EMAIL_BLIND_INDEX_SALT.
+#[test]
+fn test_blind_index_consistency_with_canonical_salt() {
+    let email = "user@example.com";
+
+    let idx1 = blind_index::compute_blind_index(email, blind_index::EMAIL_BLIND_INDEX_SALT).unwrap();
+    let idx2 = blind_index::compute_blind_index(email, blind_index::EMAIL_BLIND_INDEX_SALT).unwrap();
+    assert_eq!(idx1, idx2);
+
+    // Case insensitive
+    let idx3 = blind_index::compute_blind_index("User@Example.COM", blind_index::EMAIL_BLIND_INDEX_SALT).unwrap();
+    assert_eq!(idx1, idx3);
+
+    // Different emails produce different indices
+    let idx4 = blind_index::compute_blind_index("other@example.com", blind_index::EMAIL_BLIND_INDEX_SALT).unwrap();
+    assert_ne!(idx1, idx4);
+}
+
+/// Verification token roundtrip: encrypt a known token, decrypt, compare.
+/// This mirrors the registration/unlock flow.
+#[test]
+fn test_verification_token_roundtrip() {
+    let password = b"test_verification";
+    let device_key = keys::generate_device_key();
+    let salt = argon2_kdf::generate_salt();
+
+    let master_key = keys::reconstruct_master_key(password, &device_key, &salt).unwrap();
+
+    // Encrypt verification token (same pattern as register command)
+    let token = b"SALADVAULT_VERIFIED";
+    let (nonce, ciphertext) = xchacha::encrypt(master_key.as_bytes(), token).unwrap();
+
+    // Simulate unlock: reconstruct key with same inputs, decrypt, verify
+    let mk2 = keys::reconstruct_master_key(password, &device_key, &salt).unwrap();
+    let decrypted = xchacha::decrypt(mk2.as_bytes(), &nonce, &ciphertext).unwrap();
+    assert_eq!(decrypted, token);
+}
+
+/// Device key file must have exactly 32 bytes; corrupted files should error.
+#[test]
+fn test_device_key_invalid_size_rejected() {
+    let tmp = TempDir::new().unwrap();
+    let key_path = tmp.path().join("bad.key");
+
+    // Write a key that is too short
+    std::fs::write(&key_path, &[0u8; 16]).unwrap();
+    assert!(keys::load_device_key(&key_path).is_err());
+
+    // Write a key that is too long
+    std::fs::write(&key_path, &[0u8; 64]).unwrap();
+    assert!(keys::load_device_key(&key_path).is_err());
+}
+
+/// Missing device key file should return KeyFileNotFound.
+#[test]
+fn test_device_key_missing_file() {
+    let tmp = TempDir::new().unwrap();
+    let key_path = tmp.path().join("nonexistent.key");
+    let err = keys::load_device_key(&key_path).unwrap_err();
+    assert!(format!("{err:?}").contains("KeyFileNotFound"));
+}


### PR DESCRIPTION
## Summary
- Set chmod 600 on `device_secret.key` after creation (Unix only) to prevent other users from reading the key
- Centralize `EMAIL_BLIND_INDEX_SALT` in `blind_index` module, removing duplicate constants from `auth.rs` and `sync/commands.rs`
- Document PEPPER threat model rationale (compile-time constant is acceptable for local-first desktop app)
- Add 7 integration tests covering full Dual-Lock cycle, key sensitivity, blind index consistency, and verification token roundtrip

## Test plan
- [x] `cargo test` — 17/17 pass (10 unit + 7 integration)
- [ ] Verify device_secret.key has 0o600 permissions on Linux/macOS after registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)